### PR TITLE
Least-in-flight grouping selector

### DIFF
--- a/examples/slacker/example/cluster_client.clj
+++ b/examples/slacker/example/cluster_client.clj
@@ -18,7 +18,7 @@
 (defn-remote sc async-timestamp
   :remote-name "timestamp"
   :remote-ns "slacker.example.api"
-  :grouping :all
+  :grouping :least-in-flight
   :grouping-results :map
   :async? true
   :callback (fn [e r]

--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
   :profiles {:example {:source-paths ["examples"]
                        :dependencies [[org.apache.curator/curator-test "2.11.0"]]}
              :dev {:dependencies [[org.clojure/clojure "1.8.0"]
-                                  [slacker "0.14.2"]
+                                  [slacker "0.14.3-SNAPSHOT"]
                                   [log4j "1.2.17"]
                                   [org.slf4j/slf4j-log4j12 "1.7.21"]]}
              :clojure17 {:dependencies [[org.clojure/clojure "1.7.0"]]}

--- a/src/slacker/client/cluster.clj
+++ b/src/slacker/client/cluster.clj
@@ -380,8 +380,8 @@
   (->> servers
        (map #(if-let [sr (get @(.-slacker-clients client) %)]
                (let [sc (.-sc ^ServerRecord sr)
-                     pendings (:pendings (get-purgatory (.-factory ^SlackerClient @sc) %))]
-                 (if (some? pendings) (count @pendings) Integer/MAX_VALUE))
+                     pendings (pending-count @sc)]
+                 (if (some? pendings) pendings Integer/MAX_VALUE))
                Integer/MAX_VALUE))
        (zipmap servers)
        (sort-by second)


### PR DESCRIPTION
This patch adds a new `:least-in-flight` selector as `:grouping` option. Using this grouping selector, the cluster client will always route requests to a client with least pending requests.