### PR TITLE
Manifold for async result 

### DIFF
--- a/examples/slacker/example/cluster_client.clj
+++ b/examples/slacker/example/cluster_client.clj
@@ -29,14 +29,14 @@
 ;; requests, and return a map of result, of which key is the address
 ;; of provider. Returns a promise, and a callback is registered and
 ;; will be called when result is ready.
-(defn-remote sc async-timestamp
+(defn-remote sc async-timestamp-cb
   :remote-name "timestamp"
   :remote-ns "slacker.example.api"
   :grouping :least-in-flight
   :grouping-results :map
   :async? true
   :callback (fn [e r]
-              (println "++++" r)))
+              (println "Callback:" r)))
 
 ;; You can access more then 1 remote namespace.
 (defn-remote sc echo2
@@ -49,6 +49,7 @@
   (println (echo 23))
   (println (all-timestamp))
   (println "Async call timestamp:" @(async-timestamp))
+  (async-timestamp-cb)
   (try (make-error) (catch Exception e (println "Expected exception:" (ex-data e))))
   (println (echo2 "Echo" "Some" "Data"))
 

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
   :profiles {:example {:source-paths ["examples"]
                        :dependencies [[org.apache.curator/curator-test "4.0.0"]]}
              :dev {:dependencies [[org.clojure/clojure "1.8.0"]
-                                  [slacker "0.15.2-SNAPSHOT"]
+                                  [slacker "0.16.0-SNAPSHOT"]
                                   [log4j "1.2.17"]
                                   [org.slf4j/slf4j-log4j12 "1.7.25"]]}
              :clojure18 {:dependencies [[org.clojure/clojure "1.8.0"]]}

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :dependencies [[org.apache.curator/curator-framework "4.0.0"
                   :exclusions [jline]]
                  [org.apache.curator/curator-recipes "4.0.0"]
+                 [manifold "0.1.6"]
                  [org.clojure/tools.logging "0.4.0"]]
   :profiles {:example {:source-paths ["examples"]
                        :dependencies [[org.apache.curator/curator-test "4.0.0"]]}

--- a/project.clj
+++ b/project.clj
@@ -11,7 +11,7 @@
   :profiles {:example {:source-paths ["examples"]
                        :dependencies [[org.apache.curator/curator-test "4.0.0"]]}
              :dev {:dependencies [[org.clojure/clojure "1.8.0"]
-                                  [slacker "0.15.1"]
+                                  [slacker "0.15.2-SNAPSHOT"]
                                   [log4j "1.2.17"]
                                   [org.slf4j/slf4j-log4j12 "1.7.25"]]}
              :clojure18 {:dependencies [[org.clojure/clojure "1.8.0"]]}

--- a/src/slacker/client/cluster.clj
+++ b/src/slacker/client/cluster.clj
@@ -321,13 +321,15 @@
           (logging/debug (str "calling " ns-name "/"
                               func-name " on " target-servers))
           (let [call-deferreds (mapv
-                                #(async-call-remote @(.sc ^ServerRecord %)
-                                                    ns-name
-                                                    func-name
-                                                    params
-                                                    nil
-                                                    call-options)
-                                target-conns)]
+                                #(d/chain (async-call-remote @(.sc ^ServerRecord %1)
+                                                             ns-name
+                                                             func-name
+                                                             params
+                                                             nil
+                                                             call-options)
+                                          (fn [result] (assoc result :server %2)))
+                                target-conns
+                                target-servers)]
             (grouped-deferreds grouping-fn call-deferreds call-options cb))))))
   (close [this]
     (zk/close zk-conn)

--- a/test/slacker/client/cluster_test.clj
+++ b/test/slacker/client/cluster_test.clj
@@ -7,57 +7,6 @@
             [slacker.zk :as zk])
   (:import [slacker.client.cluster ClusterEnabledSlackerClient]))
 
-(deftest test-group-promise []
-  (let [prmss (take 5 (repeatedly promise))
-        gprm (grouped-promise identity prmss nil)]
-    (dorun (map #(deliver % true) prmss))
-    (is (every? true? @gprm)))
-  (let [prmss (take 5 (repeatedly promise))
-        gprm (grouped-promise identity prmss nil)]
-    (is (= 1 (deref gprm 2 1))))
-  (let [prmss (take 5 (repeatedly promise))
-        gprm (grouped-promise identity prmss nil)]
-    (future
-      (dorun (map #(do
-                     (deliver % true)
-                     (Thread/sleep 500)) prmss)))
-    (is (every? true? (deref gprm 3000 [false])))))
-
-(deftest test-group-call-results
-  (is (:cause (group-call-results (constantly :vector)
-                                  :all
-                                  [{:cause {:error true}}
-                                   {:cause {:error true}}])))
-  (let [r (group-call-results (constantly :vector)
-                              :all
-                              [{:cause {:error true}}
-                               {}])]
-    (is (not (:cause r))
-        (= 1 (count (:result r)))))
-  (is (:cause (group-call-results (constantly :vector)
-                                  :any
-                                  [{:cause {:error true}}
-                                   {:result 1}])))
-  (is (count
-       (:result
-        (group-call-results (constantly :vector)
-                            :any
-                            [{:result 1}
-                             {:result 2}]))))
-  (let [r (group-call-results (constantly :map)
-                              :any
-                              [{:result 1 :server "1"}
-                               {:result 2 :server "2"}])]
-    (is (= 1 (-> r :result (get "1")))))
-  (let [grf (fn []
-              (fn [results]
-                (reduce + (map :result results))))
-        r (group-call-results grf
-                              :all
-                              [{:result 1}
-                               {:result 2}])]
-    (is (= 3 (:result r)))))
-
 (deftest sync-call-test
   (testing "unavialble-value"
     (let [client (ClusterEnabledSlackerClient. "dummy-cluster"


### PR DESCRIPTION
Use Manifold for async result as sunng87/slacker#43 described. This patch also fixes async result bugs in previous slacker-cluster release.