### PR TITLE
auto detect ip with all zookeeper address

### DIFF
--- a/src/slacker/server/cluster.clj
+++ b/src/slacker/server/cluster.clj
@@ -22,8 +22,7 @@
                       zk-port (Integer/parseInt (second zk-address))]
                   (with-open [socket (Socket.)]
                     (.connect ^Socket socket (InetSocketAddress. ^String zk-ip (int zk-port)) 5000)
-                    (when (.isConnected socket)
-                      (.getHostAddress (.getLocalAddress socket)))))
+                    (.getHostAddress (.getLocalAddress socket))))
                 (catch Exception ex
                   (logging/warnf ex "Auto detect ip with zookeeper address:\"%s\" failed, try next one"
                                  zk-addr))))


### PR DESCRIPTION
Zookeeper is fully functional as long as there are enough nodes are alive. Such as 2 of 5 nodes in a cluster are dead but Zookeeper can still keep it's consistency with the remaining nodes and keep working. So maybe we can detect self ip with all the configured zookeeper addresses even when some of them failed connecting to.